### PR TITLE
Constructors refactored, One line in 'PixelateThread' was removed

### DIFF
--- a/pixelate/java/nl/dionsegijn/pixelate/Pixelate.java
+++ b/pixelate/java/nl/dionsegijn/pixelate/Pixelate.java
@@ -1,6 +1,7 @@
 package nl.dionsegijn.pixelate;
 
 import android.graphics.Bitmap;
+import android.graphics.drawable.BitmapDrawable;
 import android.support.annotation.NonNull;
 import android.widget.ImageView;
 
@@ -17,16 +18,16 @@ public class Pixelate implements OnPixelateListener {
     private ImageView targetImageView;
     private boolean loadIntoImageView = true;
 
-    public Pixelate(@NonNull Bitmap bitmap) {
+    public Pixelate(@NonNull Bitmap bitmap, final ImageView imageView) {
         pixelateThread = new PixelateThread();
+        this.targetImageView = imageView;
         setBitmap(bitmap);
     }
 
     public Pixelate(@NonNull final ImageView imageView) {
         pixelateThread = new PixelateThread();
         this.targetImageView = imageView;
-        imageView.setDrawingCacheEnabled(true);
-        setBitmap(imageView.getDrawingCache());
+        setBitmap(((BitmapDrawable)imageView.getDrawable()).getBitmap());
     }
 
     public Pixelate setShouldHandleImageView(boolean loadIntoImageView) {


### PR DESCRIPTION
1. First constructor in  'Pixelate' returns no bitmap and does not show any change such that it is not useful in android development, so just added an imageView as a second parameter.

2. Second constructor in 'Pixelate' contains deprecated methods, so just removed them and changed the logic. 